### PR TITLE
elliptics: moved read/write to purely go objects, added go structures

### DIFF
--- a/elliptics/callback.go
+++ b/elliptics/callback.go
@@ -22,23 +22,27 @@ func go_final_callback(err int, context unsafe.Pointer) {
 //export go_lookup_callback
 func go_lookup_callback(result *C.struct_go_lookup_result, context unsafe.Pointer) {
 	callback := *(*func(*lookupResult))(context)
-	Result := lookupResult{
-		info: *result.info,
-		addr: *result.addr,
-		path: C.GoString(result.path),
-		err:  nil,
+	Result := lookupResult {
+		cmd:	NewDnetCmd(result.cmd),
+		addr:	NewDnetAddr(result.addr),
+		info:	NewDnetFileInfo(result.info),
+		storage_addr:	NewDnetAddr(result.storage_addr),
+		path:	C.GoString(result.path),
+		err:	nil,
 	}
 	callback(&Result)
 }
 
 //export go_read_callback
-func go_read_callback(item *C.struct_go_read_result, context unsafe.Pointer) {
+func go_read_callback(result *C.struct_go_read_result, context unsafe.Pointer) {
 	callback := *(*func(readResult))(context)
 
-	Result := readResult{
-		data:   C.GoStringN(item.file, C.int(item.size)),
-		ioAttr: *item.io_attribute,
-		err:    nil,
+	Result := readResult {
+		cmd:	NewDnetCmd(result.cmd),
+		addr:	NewDnetAddr(result.addr),
+		ioattr:	NewDnetIOAttr(result.io_attribute),
+		data:	C.GoStringN(result.file, C.int(result.size)),
+		err:	nil,
 	}
 	// All data from C++ has been copied here.
 	callback(Result)

--- a/elliptics/ctogo.go
+++ b/elliptics/ctogo.go
@@ -1,0 +1,134 @@
+/*
+ * 2014+ Copyright (c) Evgeniy Polyakov <zbr@ioremap.net>
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
+package elliptics
+
+/*
+#include "session.h"
+#include <stdio.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"time"
+	"unsafe"
+)
+
+type DnetID struct {
+	ID	[]byte
+	Group	uint32
+	Trace	uint64
+}
+
+type DnetCmd struct {
+	ID	DnetID
+	Status	int32
+	Cmd	int32
+	Flags	uint64
+	Trans	uint64
+	Size	uint64
+}
+
+func NewDnetCmd(cmd *C.struct_dnet_cmd) DnetCmd {
+	return DnetCmd {
+		ID: DnetID {
+			ID: C.GoBytes(unsafe.Pointer(&cmd.id.id[0]), C.int(len(cmd.id.id))),
+			Group: uint32(cmd.id.group_id),
+			Trace: uint64(cmd.id.trace_id),
+		},
+
+		Status:	int32(cmd.status),
+		Cmd:	int32(cmd.cmd),
+		Flags:	uint64(cmd.flags),
+		Trans:	uint64(cmd.trans),
+		Size:	uint64(cmd.size),
+	}
+}
+
+type DnetAddr struct {
+	Addr	[]byte
+	Family	uint16
+}
+
+func NewDnetAddr(addr *C.struct_dnet_addr) DnetAddr {
+	return DnetAddr {
+		Addr:	C.GoBytes(unsafe.Pointer(&addr.addr[0]), C.int(addr.addr_len)),
+		Family:	uint16(addr.family),
+	}
+}
+
+func (a *DnetAddr) String() string {
+	var tmp C.struct_dnet_addr
+	var arrayptr = uintptr(unsafe.Pointer(&tmp.addr[0]))
+	for i := 0; i < len(a.Addr); i++ {
+		*(*C.uint8_t)(unsafe.Pointer(arrayptr)) = C.uint8_t(a.Addr[i])
+		arrayptr++
+	}
+
+	tmp.addr_len = C.uint16_t(len(a.Addr))
+	tmp.family = C.uint16_t(a.Family)
+
+	return fmt.Sprintf("%s:%d", C.GoString(C.dnet_server_convert_dnet_addr(&tmp)), a.Family)
+}
+
+type DnetIOAttr struct {
+	Parent		[]byte
+	ID		[]byte
+
+	Start		uint64
+	Num		uint64
+
+	Timestamp	time.Time
+	UserFlags	uint64
+
+	TotalSize	uint64
+
+	Flags		uint32
+
+	Offset		uint64
+	Size		uint64
+}
+
+func NewDnetIOAttr(io *C.struct_dnet_io_attr) DnetIOAttr {
+	return DnetIOAttr {
+		Parent:		C.GoBytes(unsafe.Pointer(&io.parent[0]), C.int(C.DNET_ID_SIZE)),
+		ID:		C.GoBytes(unsafe.Pointer(&io.id[0]), C.int(C.DNET_ID_SIZE)),
+		Start:		uint64(io.start),
+		Num:		uint64(io.num),
+		Timestamp:	time.Unix(int64(io.timestamp.tsec), int64(io.timestamp.tnsec)),
+		UserFlags:	uint64(io.user_flags),
+		TotalSize:	uint64(io.total_size),
+		Flags:		uint32(io.flags),
+		Offset:		uint64(io.offset),
+		Size:		uint64(io.size),
+	}
+}
+
+type DnetFileInfo struct {
+	Csum		[]byte
+	Offset		uint64
+	Size		uint64
+	Mtime		time.Time
+}
+
+func NewDnetFileInfo(info *C.struct_dnet_file_info) DnetFileInfo {
+	return DnetFileInfo {
+		Csum:	C.GoBytes(unsafe.Pointer(&info.checksum[0]), C.int(C.DNET_ID_SIZE)),
+		Offset:		uint64(info.offset),
+		Size:		uint64(info.size),
+		Mtime:		time.Unix(int64(info.mtime.tsec), int64(info.mtime.tnsec)),
+	}
+}

--- a/elliptics/session.cpp
+++ b/elliptics/session.cpp
@@ -64,7 +64,8 @@ void on_read(void *context, const elliptics::read_result_entry & result)
 {
 	elliptics::data_pointer data(result.file());
 	go_read_result to_go {
-		(char *)data.data(), data.size(), result.io_attribute()
+		result.command(), result.address(),
+		result.io_attribute(), (char *)data.data(), data.size()
 	};
 
 	go_read_callback(&to_go, context);
@@ -84,6 +85,7 @@ void session_read_data(ell_session *session, void *on_chunk_context,
 void on_lookup(void *context, const elliptics::lookup_result_entry & result)
 {
 	go_lookup_result to_go {
+		result.command(), result.address(),
 		result.file_info(), result.storage_address(), result.file_path()
 	};
 
@@ -129,7 +131,7 @@ void session_remove(ell_session *session, void *on_chunk_context,
 /*
  * Find
  */
-void on_find(void *context, const elliptics::find_indexes_result_entry & result)
+void on_find(void *context, const elliptics::find_indexes_result_entry &result)
 {
 	std::vector <c_index_entry> c_index_entries;
 

--- a/elliptics/session.go
+++ b/elliptics/session.go
@@ -1,16 +1,16 @@
 /*
-* 2013+ Copyright (c) Anton Tyurin <noxiouz@yandex.ru>
-* All rights reserved.
-*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
+ * 2013+ Copyright (c) Anton Tyurin <noxiouz@yandex.ru>
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
  */
 
 package elliptics
@@ -90,24 +90,42 @@ func (s *Session) SetNamespace(namespace string) {
 
 //ReadResult wraps one result of read operation.
 type ReadResult interface {
-	//Data returns string represntation of readed data.
+	// server's reply
+	Cmd() *DnetCmd
+
+	// server's address
+	Addr() *DnetAddr
+
+	// IO parameters for given 
+	IO() *DnetIOAttr
+
+	//Data returns string represntation of read data
 	Data() string
-	//Error returns representation of error, which could occur.
+
+	// read error
 	Error() error
 }
 
 type readResult struct {
-	ioAttr C.struct_dnet_io_attr
-	data   string
-	err    error
+	cmd	DnetCmd
+	addr	DnetAddr
+	ioattr	DnetIOAttr
+	data	string
+	err	error
 }
 
-//Data returns a string represntation of readed data.
+func (r *readResult) Cmd() *DnetCmd {
+	return &r.cmd
+}
+func (r *readResult) Addr() *DnetAddr {
+	return &r.addr
+}
+func (r *readResult) IO() *DnetIOAttr {
+	return &r.ioattr
+}
 func (r *readResult) Data() string {
 	return r.data
 }
-
-//Error returns representation of error, which could occur.
 func (r *readResult) Error() error {
 	return r.err
 }
@@ -150,34 +168,49 @@ func (s *Session) ReadData(key string) <-chan ReadResult {
 
 //Lookuper represents one result of Write and Lookup operations.
 type Lookuper interface {
-	//Path returns a path to lookuped key.
+	// server's reply
+	Cmd() *DnetCmd
+
+	// server's address
+	Addr() *DnetAddr
+
+	// dnet_file_info structure contains basic information about key location
+	Info() *DnetFileInfo
+
+	// address of the node which hosts given key
+	StorageAddr() *DnetAddr
+
+	//Path returns a path to file hosting given key on the storage.
 	Path() string
-	//Addr returns dnet_addr for a lookuped key.
-	Addr() C.struct_dnet_addr
-	Info() C.struct_dnet_file_info
+
 	//Error returns string respresentation of error.
 	Error() error
 }
 
 type lookupResult struct {
-	info C.struct_dnet_file_info //dnet_file_info
-	addr C.struct_dnet_addr
-	path string //file_path
-	err  error
+	cmd		DnetCmd
+	addr		DnetAddr
+	info		DnetFileInfo
+	storage_addr	DnetAddr
+	path		string
+	err		error
 }
 
+func (l *lookupResult) Cmd() *DnetCmd {
+	return &l.cmd
+}
+func (l *lookupResult) Addr() *DnetAddr {
+	return &l.addr
+}
+func (l *lookupResult) Info() *DnetFileInfo {
+	return &l.info
+}
+func (l *lookupResult) StorageAddr() *DnetAddr {
+	return &l.storage_addr
+}
 func (l *lookupResult) Path() string {
 	return l.path
 }
-
-func (l *lookupResult) Addr() C.struct_dnet_addr {
-	return l.addr
-}
-
-func (l *lookupResult) Info() C.struct_dnet_file_info {
-	return l.info
-}
-
 func (l *lookupResult) Error() error {
 	return l.err
 }

--- a/elliptics/session.h
+++ b/elliptics/session.h
@@ -31,16 +31,20 @@ typedef void ell_session;
 
 //read_result_entry
 struct go_read_result {
-	char			*file;
-	size_t			size;
-	struct dnet_io_attr	*io_attribute;
+	const struct dnet_cmd		*cmd;
+	const struct dnet_addr		*addr;
+	const struct dnet_io_attr	*io_attribute;
+	char				*file;
+	size_t				size;
 };
 
 //lookup_result_entry
 struct go_lookup_result {
-	struct dnet_file_info	*info;
-	struct dnet_addr	*addr;
-	const char		*path;
+	const struct dnet_cmd		*cmd;
+	const struct dnet_addr		*addr;
+	const struct dnet_file_info	*info;
+	const struct dnet_addr		*storage_addr;
+	const char			*path;
 };
 
 //index_entry
@@ -52,7 +56,7 @@ struct c_index_entry {
 //find_indexes_result_entry
 struct go_find_result {
 	const struct dnet_raw_id	*id;
-	size_t				entries_count;
+	const size_t			entries_count;
 	struct c_index_entry		*entries;
 };
 


### PR DESCRIPTION
Added appropriate go structures and helper function.
Indexes should be either removed or moved to this new functionality too.

This might affect S3 implementation, do we need it right there?
Please take a look at bioothod/backrunner go proxy, should S3 be implemented natively like backrunner?
