### PR TITLE
stream API fixes

### DIFF
--- a/elliptics/session.go
+++ b/elliptics/session.go
@@ -245,7 +245,7 @@ func (s *Session) StreamHTTP(kstr string, offset, size uint64, w http.ResponseWr
 
 			if offset == orig_offset {
 				w.Header().Set("Content-Length", fmt.Sprintf("%d", rd.IO().TotalSize - offset))
-				if size == 0 {
+				if size == 0 || size > rd.IO().TotalSize - offset {
 					size = rd.IO().TotalSize - offset
 				}
 


### PR DESCRIPTION
zero size means 'read everything' and we should read the whole file only when size was either 0 or large enough to be more than file size
